### PR TITLE
Use lowercase for Sigma logo so it doesn't error on Linux.

### DIFF
--- a/factions/corp-sigma.xml
+++ b/factions/corp-sigma.xml
@@ -4,7 +4,7 @@
  <static />
  <known />
  <player>90</player>
- <logo>Sigma</logo>
+ <logo>sigma</logo>
  <description>Sigma Shipyards is the major Federation shipwright. They also fabricate venerable Manifest-era bulk-freighter designs, which they use to trade through Hypergates (of which they are the sole modern user) for great profit. Sigma is the logistical backbone of the universe.</description>
  <colour r="0.6980392157" g="0.6980392157" b="0.6980392157" />
  <spawn>testers</spawn>


### PR DESCRIPTION
Linux is case sensitive.