### PR TITLE
Earth->Vulcan/Luna gone

### DIFF
--- a/spob/sectorapex/thror.xml
+++ b/spob/sectorapex/thror.xml
@@ -23,7 +23,7 @@
    <commodity/>
   </services>
   <commodities/>
-  <description>Thror is to Thraine what Luna is to the Earth. Thror has been strip-mined for some decades now, and it continues to provide much of the raw material for Federation activities throughout this sector of space.</description>
+  <description>Thror is to Thraine what Luna was to the Earth. Thror has been strip-mined for some decades now, and it continues to provide much of the raw material for Federation activities throughout this sector of space.</description>
  </general>
  <tags>
   <tag>federationera</tag>

--- a/spob/sectorkane/spacedock_ii.xml
+++ b/spob/sectorkane/spacedock_ii.xml
@@ -26,7 +26,7 @@
    <shipyard/>
   </services>
   <commodities/>
-  <description>Spacedock II is the headquarters for the Federation Navy's logistics department. The base is also utilized as a secondary repair and outfitting facility with the shipyards on the Kane Band around Earth being primary. Materials and parts produced on nearby Kiniké are shipped up and assembled on base. However, the primary purpose of this base is to provide a home for the people who have to keep track of the Federation military on a day-to-day basis. An occasional Auroran skirmish keeps the pilots and gunners of Spacedock II on their toes, as the Auroran commanders see Spacedock II as a important link in the Federation's logistics chain.</description>
+  <description>Spacedock II is the headquarters for the Federation Navy's logistics department. The base is also utilized as a secondary repair and outfitting facility with the shipyards on the Kane Band around Vulcan being primary. Materials and parts produced on nearby Kiniké are shipped up and assembled on base. However, the primary purpose of this base is to provide a home for the people who have to keep track of the Federation military on a day-to-day basis. An occasional Auroran skirmish keeps the pilots and gunners of Spacedock II on their toes, as the Auroran commanders see Spacedock II as a important link in the Federation's logistics chain.</description>
   <bar>Welcome to Remf's. The officer in charge of the mess, Lt. Col. Reynold M. French, ensures that this bar is open at all times, except for when the soldiers are off-duty.</bar>
  </general>
  <tech>

--- a/spob/sectorprimus/snowmelt.xml
+++ b/spob/sectorprimus/snowmelt.xml
@@ -25,7 +25,7 @@
    <shipyard/>
   </services>
   <commodities/>
-  <description>Snowmelt is the second-largest gathering of humanity in the Federation behind Earth itself (including the Kane Band). The planet itself is extremely cold. Most of the population is concentrated in a thousand mile wide strip along the equator where temperatures stay within 35 degrees of zero. Outside of this, the temperatures decrease rapidly to the poles, where the average temperature is in the region of -200 degrees Celsius. Snowmelt seems to lack any major natural resources. However, due to the ease of building habitable quarters by hollowing out the ice, the population exceeds ten billion.</description>
+  <description>Snowmelt is the second-largest gathering of humanity in the Federation behind Vulcan itself (including the Kane Band). The planet itself is extremely cold. Most of the population is concentrated in a thousand mile wide strip along the equator where temperatures stay within 35 degrees of zero. Outside of this, the temperatures decrease rapidly to the poles, where the average temperature is in the region of -200 degrees Celsius. Snowmelt seems to lack any major natural resources. However, due to the ease of building habitable quarters by hollowing out the ice, the population exceeds ten billion.</description>
   <bar>This bar is filled with young people who seem to be disaffected with life on Snowmelt. They come here to tell each other their dreams and plans for escaping their dreary lives.</bar>
  </general>
  <tech>


### PR DESCRIPTION
Changes Snowmelt and Spacedock II's descriptions to refer to Vulcan instead of Earth, as they mention the Kane Band. Changes Thror to make a comparison to Luna/Earth in past tense (since Earth is at least effectively gone from the perspective of the Federation here).