### PR TITLE
Use new semver-based version syntax.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin name="Neava">
  <author>RavelinW</author>
  <version>0.1</version>
- <compatibility>^0\.13..*</compatibility>
+ <naev_version>&gt;=0.13.0-0, &lt;0.14.0</naev_version>
  <priority>1</priority>
  <total_conversion/>
  <description>A total conversion for Naev that adds a reimagined Novaverse. </description>


### PR DESCRIPTION
Will change to new system on the next nightly that will raise a deprecated warning. Using semver is also cleaner, although because it's XML it looks ugly with escaping `<` and `>`.